### PR TITLE
revert to bare price for backward compatibility and add -timestamped_price file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ feeds/
     BTCUSD-30d - an array of the last 30 daily candle closes (covers 1 month)
 ```
 
-The files ending `-last` will contain array of 2 elements, defined as such: 
-1. the unix timestamp as string
+
+Files ending `-last` will contain a single string of the last price. For example '1234.56'.
+
+Files ending `-timestamped_price` will contain array of 2 elements, defined as such: 
+1. the unix timestamp as an integer
 2. the last price truncated to the integer part as string  
 
-For example `['1670344382195','2322400']`.
+For example `[1670344382195,'2322400']`.
 
 Files ending `-24h`, `-7d` and `-30d` will contain an array of strings. Oldest value first. 
-For example, `[ ['1670344382195', '1234.45'], ['1670344382195', '1245.78'], ['1670344382195', '1267.78'], ... ]`
+For example, `[ '1234.45', '1245.78', '1267.78', ... ]`
 
 The public key and encryption key of the drive are published to the logs when the app is started.

--- a/test/bitfinex-price-feed.js
+++ b/test/bitfinex-price-feed.js
@@ -29,10 +29,18 @@ describe('Price feed', () => {
       await feeds._updateLivePrice(mocks.testTicker)
     })
 
-    it('gets stored in hyperdrive', async () => {
+    it('-last gets stored in hyperdrive', async () => {
       const res = await feeds.feedStorage.get(config.driveId, `${mocks.testTicker.base}${mocks.testTicker.quote}-last`)
 
+      assert(res - (new Date().getTime()) < 0)
+      assert.equal(res, feeds._formatPrice(mocks.LAST_RESPONSE[6]))
+    })
+
+    it('-timestamped_price gets stored in hyperdrive', async () => {
+      const res = await feeds.feedStorage.get(config.driveId, `${mocks.testTicker.base}${mocks.testTicker.quote}-timestamped_price`)
+
       assert.equal(res.length, 2)
+      assert.ok(typeof res[0] === 'number')
       assert(res[0] - (new Date().getTime()) < 0)
       assert.equal(res[1], feeds._formatPrice(mocks.LAST_RESPONSE[6]))
     })
@@ -50,9 +58,7 @@ describe('Price feed', () => {
       assert.equal(res.length, 24)
       const sortedResponse = mocks.ONE_DAY_RESPONSE.sort((a, b) => a[0] - b[0])
       for (let i = 0; i < res.length; i++) {
-        assert.equal(res[i].length, 2)
-        assert.equal(res[i][0], sortedResponse[i][0])
-        assert.equal(res[i][1], feeds._formatPrice(sortedResponse[i][2]))
+        assert.equal(res[i], feeds._formatPrice(sortedResponse[i][2]))
       }
     })
   })
@@ -70,8 +76,7 @@ describe('Price feed', () => {
       assert.equal(res.length, 14)
       const sortedResponse = mocks.ONE_WEEK_RESPONSE_12H.slice(1, 15).sort((a, b) => a[0] - b[0])
       for (let i = 0; i < res.length; i++) {
-        assert.equal(res[i][0], sortedResponse[i][0])
-        assert.equal(res[i][1], feeds._formatPrice(sortedResponse[i][2]))
+        assert.equal(res[i], feeds._formatPrice(sortedResponse[i][2]))
       }
     })
   })
@@ -89,9 +94,9 @@ describe('Price feed', () => {
 
       const sortedResponse = mocks.ONE_WEEK_RESPONSE_1D.slice(1, 31).sort((a, b) => a[0] - b[0])
       for (let i = 0; i < res.length; i++) {
-        assert.equal(res[i][0], sortedResponse[i][0])
-        assert.equal(res[i][1], feeds._formatPrice(sortedResponse[i][2]))
+        assert.equal(res[i], feeds._formatPrice(sortedResponse[i][2]))
       }
     })
   })
 })
+


### PR DESCRIPTION
A suggestion to support oracle feeds, without disrupting price widgets in the current Bitkit versions